### PR TITLE
Fix scroll position reset on route changes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { Layout } from './components/Layout';
 import { AdminRoute } from './components/ProtectedRoute';
+import { ScrollToTop } from './components/ScrollToTop';
 import { Login } from './pages/Login';
 import { Info } from './pages/Info';
 import { Events } from './pages/Events';
@@ -12,6 +13,7 @@ import { Admin } from './pages/Admin';
 function App() {
   return (
     <BrowserRouter>
+      <ScrollToTop />
       <Routes>
         {/* Auth route */}
         <Route path="/login" element={<Login />} />

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a ScrollToTop router helper that listens to pathname changes
- mount the helper once under BrowserRouter so every navigation starts at top
- keep behavior intentionally minimal and deterministic

## Test plan
- [x] Navigate between public routes after scrolling down and verify the next page opens at top
- [x] Navigate to /admin and verify route change also resets to top
- [x] Confirm lint reports no issues in touched files (src/App.tsx, src/components/ScrollToTop.tsx)

Closes #3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to client-side navigation; potential impact is mainly UX if some pages expected preserved scroll position.
> 
> **Overview**
> Adds a `ScrollToTop` helper that listens to `react-router` `pathname` changes and calls `window.scrollTo(0, 0)`.
> 
> Mounts `ScrollToTop` once under `BrowserRouter` in `App.tsx` so every route navigation (including protected routes) starts at the top of the page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30b0f8daf0cf0b4ecad058d5f6841c181ef94009. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->