### PR TITLE
Automate issue state to done on merge

### DIFF
--- a/.github/workflows/issue-state-on-merge.yml
+++ b/.github/workflows/issue-state-on-merge.yml
@@ -1,0 +1,91 @@
+name: Update issue state on merged PR
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  mark-linked-issues-done:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move linked issues to state:done
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || "";
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Match closing references like:
+            // Closes #3, Fixes #3, Resolves owner/repo#3
+            const closingRegex =
+              /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/(\d+)|([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)#(\d+)|#(\d+))/gi;
+
+            const issueTargets = new Map();
+            let match;
+
+            while ((match = closingRegex.exec(body)) !== null) {
+              if (match[1]) {
+                issueTargets.set(`${owner}/${repo}#${match[1]}`, {
+                  owner,
+                  repo,
+                  number: Number(match[1]),
+                });
+                continue;
+              }
+
+              if (match[2] && match[3] && match[4]) {
+                issueTargets.set(`${match[2]}/${match[3]}#${match[4]}`, {
+                  owner: match[2],
+                  repo: match[3],
+                  number: Number(match[4]),
+                });
+                continue;
+              }
+
+              if (match[5]) {
+                issueTargets.set(`${owner}/${repo}#${match[5]}`, {
+                  owner,
+                  repo,
+                  number: Number(match[5]),
+                });
+              }
+            }
+
+            if (issueTargets.size === 0) {
+              core.info("No closing issue references found in PR body.");
+              return;
+            }
+
+            for (const target of issueTargets.values()) {
+              const { data: issue } = await github.rest.issues.get({
+                owner: target.owner,
+                repo: target.repo,
+                issue_number: target.number,
+              });
+
+              const nextLabels = (issue.labels || [])
+                .map((label) => (typeof label === "string" ? label : label.name))
+                .filter((name) => name && !name.startsWith("state:"));
+
+              if (!nextLabels.includes("state:done")) {
+                nextLabels.push("state:done");
+              }
+
+              await github.rest.issues.setLabels({
+                owner: target.owner,
+                repo: target.repo,
+                issue_number: target.number,
+                labels: nextLabels,
+              });
+
+              core.info(
+                `Updated ${target.owner}/${target.repo}#${target.number} to state:done`
+              );
+            }


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs when a PR is merged
- parse PR body for closing keywords and linked issue references
- replace any existing state:* label with state:done on linked issues

## Notes
- works for references like Closes #123, Fixes #123, and Resolves owner/repo#123
- only runs on merged PRs (pull_request.closed with merged == true)