### PR TITLE
Prioritize high-reasoning planning in workflow docs

### DIFF
--- a/.cursor/rules/core-workflow.mdc
+++ b/.cursor/rules/core-workflow.mdc
@@ -41,6 +41,10 @@ alwaysApply: true
 
 ## 3) Implement Issue
 - Implement only after plan approval.
+- Before starting new work, check branch/PR freshness:
+  - If current branch has a PR that is `merged` or `closed`, do not continue on that branch.
+  - Create a new feature branch from latest `master` and open a new PR for new commits.
+  - Keep one active change stream per branch/PR pair.
 - If the user says "Implement issue #<N>", implement the actual GitHub issue number `<N>` in the current repository.
 - Use the latest approved plan from that issue's comments as the implementation source of truth.
 - Do not implement unless the issue has label `state:planned`.

--- a/.cursor/rules/core-workflow.mdc
+++ b/.cursor/rules/core-workflow.mdc
@@ -19,6 +19,9 @@ alwaysApply: true
 
 ## 2) Plan Issue
 - Planning is the main thinking stage.
+- Planning is the highest-priority quality gate in this workflow.
+- For planning, use the highest-reasoning model available.
+- Prefer deeper analysis in planning than in implementation (more repo reading, trade-off analysis, and risk checks).
 - Read the repository before proposing a plan.
 - Identify impacted files and frontend/backend surfaces.
 - Ask clarifying questions before finalizing the plan when needed.

--- a/WORKFLOW_CHEATSHEET.md
+++ b/WORKFLOW_CHEATSHEET.md
@@ -35,6 +35,11 @@ Prompt:
 Plan issue #<N>
 ```
 
+Planning priority:
+- planning is the most important quality gate
+- use the highest-reasoning model available
+- do deeper analysis here than during implementation
+
 Plan comment format must include:
 - `## Plan`
 - `## Affected Files`

--- a/WORKFLOW_CHEATSHEET.md
+++ b/WORKFLOW_CHEATSHEET.md
@@ -59,6 +59,11 @@ Prompt:
 Implement issue #<N>
 ```
 
+Branch/PR freshness check (before coding):
+1. check whether current branch PR is open or already merged/closed
+2. if merged/closed, create a new feature branch from latest `master`
+3. use a new PR for the new work (do not append commits to old merged PR branches)
+
 Expected sequence:
 1. use latest approved plan from issue comments
 2. move label to `state:in-progress`


### PR DESCRIPTION
## Summary
- make planning the highest-priority quality gate in core-workflow
- require using the highest-reasoning model available during planning
- mirror this guidance in WORKFLOW_CHEATSHEET.md

## Test plan
- [x] Verify rule text is present in .cursor/rules/core-workflow.mdc
- [x] Verify cheatsheet includes the same planning-priority guidance


Made with [Cursor](https://cursor.com)