### PR TITLE
Implement automatic MVG distinction from Gemschi Score

### DIFF
--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -90,6 +90,10 @@ Each player profile includes:
 - Name
 - Nickname (Alias)
 - Role (Spieler, Captain, CEO of Patchio)
+- MVG distinction (computed automatically from the highest Gemschi Score in the selected season)
+- MVG label format: `MVG of <selected season year>`
+- If multiple players share the exact highest Gemschi Score, all of them are MVG
+- If the highest Gemschi Score is `0`, no MVG is shown
 - Gemschigrad
 - Klassierung
 - Short introduction text

--- a/docs/specs/spec-030-roster-players.md
+++ b/docs/specs/spec-030-roster-players.md
@@ -46,6 +46,12 @@ Each player profile must expose the following public information:
   - Spieler
   - Captain
   - CEO of Patchio
+- MVG distinction:
+  - Is not a manually assignable role
+  - Is derived automatically from seasonal Gemschi Score
+  - Is assigned to all players with the exact highest Gemschi Score in the selected season
+  - Is assigned to no player when the highest Gemschi Score is `0`
+  - Is displayed as: `MVG of <selected season year>`
 - Gemschigrad
 - Klassierung
 
@@ -98,6 +104,7 @@ Only the Captain can manage players.
 ### Constraints
 - There may be **only one Captain** at any given time.
 - Assigning the Captain role to a player removes it from the previous Captain.
+- MVG is computed automatically and cannot be assigned manually by Captain.
 
 ---
 

--- a/src/hooks/useStatistics.ts
+++ b/src/hooks/useStatistics.ts
@@ -31,12 +31,19 @@ export interface TeamSeasonStats {
   averageGemschiScore: number;
 }
 
+function extractSelectedSeasonYear(seasonName?: string): number {
+  if (!seasonName) return new Date().getFullYear();
+  const matches = seasonName.match(/\d{4}/g);
+  if (!matches || matches.length === 0) return new Date().getFullYear();
+  return Number(matches[matches.length - 1]);
+}
+
 /**
  * Compute all statistics from seasonal inputs.
  * Statistics are NEVER stored — always derived.
  */
 export function useStatistics() {
-  const { selectedSeasonId } = useSeasons();
+  const { selectedSeasonId, selectedSeason } = useSeasons();
   const { events } = useEvents();
   const { attendance } = useAttendance();
   const { spirit } = useSpirit();
@@ -172,5 +179,30 @@ export function useStatistics() {
     };
   }, [interclubEvents, playerStats]);
 
-  return { playerStats, teamStats, getPlayerStats: (id: string) => playerStats.find(s => s.playerId === id) };
+  const mvgPlayerIds = useMemo((): string[] => {
+    if (playerStats.length === 0) return [];
+
+    const maxScore = Math.max(...playerStats.map((ps) => ps.gemschiScore));
+    if (maxScore <= 0) return [];
+
+    return playerStats
+      .filter((ps) => ps.gemschiScore === maxScore)
+      .map((ps) => ps.playerId);
+  }, [playerStats]);
+
+  const mvgYear = useMemo(
+    () => extractSelectedSeasonYear(selectedSeason?.name),
+    [selectedSeason?.name]
+  );
+
+  const mvgLabel = useMemo(() => `MVG of ${mvgYear}`, [mvgYear]);
+
+  return {
+    playerStats,
+    teamStats,
+    mvgPlayerIds,
+    mvgLabel,
+    isMvgPlayer: (id: string) => mvgPlayerIds.includes(id),
+    getPlayerStats: (id: string) => playerStats.find(s => s.playerId === id),
+  };
 }

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -9,6 +9,7 @@ import { useAttendance } from '../contexts/AttendanceContext';
 import { useSpirit } from '../contexts/SpiritContext';
 import { useInfo } from '../contexts/InfoContext';
 import { useAuth } from '../contexts/AuthContext';
+import { useStatistics } from '../hooks/useStatistics';
 import { AppEvent, EventType, SinglesGame, DoublesGame, createEmptySinglesGames, createEmptyDoublesGames, formatEventDateDisplay, getEventStartDate } from '../types/event';
 import { Player, Gemschigrad, Klassierung, PlayerRole } from '../types/player';
 import { sendNotificationToAll } from '../services/notifications';
@@ -126,6 +127,7 @@ export const Admin: React.FC = () => {
   const { getEventAttendees, setEventAttendance } = useAttendance();
   const { spirit, setPlayerSpirit } = useSpirit();
   const { tenueData, addTenueItem, updateTenueItem, removeTenueItem } = useInfo();
+  const { isMvgPlayer, mvgLabel } = useStatistics();
 
   // --- Season form ---
   const [newSeasonName, setNewSeasonName] = useState('');
@@ -526,7 +528,16 @@ export const Admin: React.FC = () => {
               <div key={player.id} className="p-4 bg-chnebel-gray rounded-lg border border-gray-200">
                 <div className="mb-2">
                   <div className="font-medium text-chnebel-black">{player.name} {player.alias && <span className="text-gray-500 italic text-sm">"{player.alias}"</span>}</div>
-                  <div className="text-sm text-gray-500">{player.role} · {player.gemschigrad} · {player.klassierung}</div>
+                  <div className="text-sm text-gray-500 flex items-center gap-2 flex-wrap">
+                    <span>{player.role}</span>
+                    {isMvgPlayer(player.id) && (
+                      <>
+                        <span className="text-amber-500">💎</span>
+                        <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-amber-100 text-amber-800">{mvgLabel}</span>
+                      </>
+                    )}
+                    <span>· {player.gemschigrad} · {player.klassierung}</span>
+                  </div>
                 </div>
                 <div className="flex flex-wrap gap-2 justify-end">
                   <button onClick={() => openEditPlayerModal(player)} className="px-3 py-1 bg-blue-500 text-white rounded text-xs hover:bg-blue-600" title="Bearbeiten">✏️</button>

--- a/src/pages/Spieler.tsx
+++ b/src/pages/Spieler.tsx
@@ -31,7 +31,7 @@ const getScoreColor = (score: number): string => {
 
 export const Spieler: React.FC = () => {
   const { players } = usePlayers();
-  const { getPlayerStats } = useStatistics();
+  const { getPlayerStats, isMvgPlayer, mvgLabel } = useStatistics();
   const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
 
   const sortedPlayers = useMemo(() => {
@@ -90,8 +90,12 @@ export const Spieler: React.FC = () => {
                         <span className="flex items-center gap-2">
                           {player.name}
                           {getRoleEmoji(player.role) && <span className="text-yellow-500">{getRoleEmoji(player.role)}</span>}
+                          {isMvgPlayer(player.id) && <span className="text-amber-500">💎</span>}
                           {player.role !== 'Spieler' && (
                             <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-yellow-100 text-yellow-800">{player.role}</span>
+                          )}
+                          {isMvgPlayer(player.id) && (
+                            <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-amber-100 text-amber-800">{mvgLabel}</span>
                           )}
                         </span>
                         {player.alias && <span className="text-sm text-gray-500 italic">"{player.alias}"</span>}
@@ -147,8 +151,12 @@ export const Spieler: React.FC = () => {
                   <div className="flex items-center gap-2 font-medium text-chnebel-black flex-wrap">
                     {player.name}
                     {getRoleEmoji(player.role) && <span className="text-yellow-500">{getRoleEmoji(player.role)}</span>}
+                    {isMvgPlayer(player.id) && <span className="text-amber-500">💎</span>}
                     {player.role !== 'Spieler' && (
                       <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-yellow-100 text-yellow-800">{player.role}</span>
+                    )}
+                    {isMvgPlayer(player.id) && (
+                      <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-amber-100 text-amber-800">{mvgLabel}</span>
                     )}
                   </div>
                   {player.alias && <div className="text-sm text-gray-500 italic truncate">"{player.alias}"</div>}
@@ -196,11 +204,15 @@ export const Spieler: React.FC = () => {
                     <h2 className="text-2xl font-bold flex items-center gap-2">
                       {selectedPlayer.name}
                       {getRoleEmoji(selectedPlayer.role) && <span className="text-yellow-300">{getRoleEmoji(selectedPlayer.role)}</span>}
+                      {isMvgPlayer(selectedPlayer.id) && <span className="text-amber-200">💎</span>}
                     </h2>
                     {selectedPlayer.alias && <p className="text-white/80 italic">"{selectedPlayer.alias}"</p>}
                     <div className="flex flex-wrap items-center gap-2 mt-1">
                       {selectedPlayer.role !== 'Spieler' && (
                         <span className="px-2 py-0.5 rounded-full text-xs font-semibold bg-yellow-400 text-yellow-900">{selectedPlayer.role}</span>
+                      )}
+                      {isMvgPlayer(selectedPlayer.id) && (
+                        <span className="px-2 py-0.5 rounded-full text-xs font-semibold bg-amber-200 text-amber-900">{mvgLabel}</span>
                       )}
                       <span className="px-2 py-0.5 rounded-full text-xs font-semibold bg-white/20">{selectedPlayer.gemschigrad}</span>
                       <span className="px-2 py-0.5 rounded-full text-xs font-semibold bg-white/20">{selectedPlayer.klassierung}</span>


### PR DESCRIPTION
## Summary
- derive MVG automatically from selected-season `gemschiScore` values in the statistics hook
- apply exact-score tie handling, zero-score fallback to no MVG, and expose a reusable MVG label (`MVG of <selected season year>`)
- render MVG icon/badge wherever player role labels are shown (`Spieler` and `Admin` player listings)

## Documentation Impact
- Updated `docs/requirements/requirements.md`
- Updated `docs/specs/spec-030-roster-players.md`

Closes #10

## Test plan
- [x] Run `npm run build`
- [x] In UI, verify MVG appears for top player(s) in `Spieler` and `Admin`
- [x] Verify ties create multiple MVG badges
- [ ] Verify all-zero scores show no MVG badge
- [x] Verify label uses selected season year
